### PR TITLE
Incorporate sentiment analysis API into comments feature

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -30,10 +30,17 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-language</artifactId>
+      <version>1.55.0</version>
     </dependency>
 
   </dependencies>

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -7,10 +7,10 @@ public final class Comment {
   private final long id;
   private final String text;
   private final String name;
-  private final float score;
+  private final double score;
   private final Date date;
 
-  public Comment(long id, String text, String name, float score, long time) {
+  public Comment(long id, String text, String name, double score, long time) {
     this.id = id;
     this.name = name;
     this.text = text;

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -7,12 +7,14 @@ public final class Comment {
   private final long id;
   private final String text;
   private final String name;
+  private final float score;
   private final Date date;
 
-  public Comment(long id, String name, String text, long time) {
+  public Comment(long id, String text, String name, float score, long time) {
     this.id = id;
     this.name = name;
     this.text = text;
+    this.score = score;
     this.date = new Date(time);
   }
 } 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -67,7 +67,7 @@ public class DataServlet extends HttpServlet {
       long time = (long) entity.getProperty("time");
       
       // Create Comment object
-      Comment comment = new Comment(id, name, text, time);
+      Comment comment = new Comment(id, text, name, score, time);
       comments.add(comment);
     }
     
@@ -101,6 +101,6 @@ public class DataServlet extends HttpServlet {
     datastore.put(commentEntity);
 
     // Redirect back to the HTML page.
-    response.sendRedirect("/index.html");
+    response.sendRedirect("/contact.html");
   }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -7,28 +7,51 @@ function getComments() {
     .then(comments => {
       const commentsListElement = document.getElementById("comments-list");
       commentsListElement.innerHTML = "";
-      comments.forEach(line => {
-        commentsListElement.appendChild(createListElement(line));
-      });
+      comments
+        .map(createListElement)
+        .forEach(line => commentsListElement.appendChild(line));
     });
 }
 
-/** Creates an <li> element containing comment data.*/
+/**
+ * Returns HTML smiley emoji based on the sentiment score.
+ */
+function returnEmoji(score) {
+  if (1 >= score && score > 0.6) {
+    return `Vibe Check: ${String.fromCodePoint(0x1f600)}\n`; // Very happy
+  } else if (0.6 >= score && score > 0.2) {
+    return `Vibe Check: ${String.fromCodePoint(0x1f642)}\n`; // Happy
+  } else if (0.2 >= score && score >= -0.2) {
+    return `Vibe Check: ${String.fromCodePoint(0x1f610)}\n`; // Neutral
+  } else if (-0.2 > score && score >= -0.6) {
+    return `Vibe Check: ${String.fromCodePoint(0x1f641)}\n`; // Upset
+  } else {
+    return `Vibe Check: ${String.fromCodePoint(0x1f614)}\n`; // Very Upset
+  }
+}
+
+/**
+ * Creates a list element containing comment data.
+ */
 function createListElement(comment) {
   const commentElement = document.createElement('li');
-  commentElement.className = 'comment';
+  commentElement.className = "comment";
 
-  const nameElement = document.createElement('b');
-  nameElement.innerText = comment.name + ": ";
+  const nameElement = document.createElement("b");
+  nameElement.innerText = `${comment.name}: `;
 
-  const textElement = document.createElement('span');
-  textElement.innerText = comment.text;
+  const textElement = document.createElement("span");
+  textElement.innerText = `${comment.text} \n`;
+
+  const emojiElement = document.createElement("span");
+  emojiElement.innerText = returnEmoji(comment.score);
 
   const timeElement = document.createElement('span');
-  timeElement.innerText = "   (" + comment.date + ")";
+  timeElement.innerText = ` Date: ${comment.date})`;
   
   commentElement.appendChild(nameElement);
   commentElement.appendChild(textElement);
+  commentElement.appendChild(emojiElement);
   commentElement.appendChild(timeElement);
 
   return commentElement;


### PR DESCRIPTION
Hi Patricia! In this PR, I've incorporated the Sentiment Analysis API into the comments feature. Each comment will be passed to the LanguageServiceClient, which returns a sentiment score. Instead of showing the score next to the comment, I created a JavaScript function to convert the score to a matching smiley emoji (sad ones for negative scores and happier ones for positive scores!). 

The comments feature was working before incorporating the Sentiment Analysis API, but now the comments don't seem to be showing up. I am in the midst of fixing some errors that came up after attempting to deploy my site (possibly due to authentication errors or careless bugs in the code), but I will let you know what my progress is like while I try to fix it!